### PR TITLE
refactor: pass props by passing props id

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -27,11 +27,11 @@ namespace JSX {
         'mask-calendar-widget': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
         'mask-page-inspector': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
         'mask-decrypted-post': React.DetailedHTMLProps<
-            React.HTMLAttributes<HTMLElement> & { props: string },
+            React.HTMLAttributes<HTMLElement> & { 'props-id': string },
             HTMLElement
         >;
         'mask-post-inspector': React.DetailedHTMLProps<
-            React.HTMLAttributes<HTMLElement> & { props: string },
+            React.HTMLAttributes<HTMLElement> & { 'props-id': string },
             HTMLElement
         >;
     }

--- a/src/mask/custom-elements/WidgetWithProps.tsx
+++ b/src/mask/custom-elements/WidgetWithProps.tsx
@@ -1,18 +1,15 @@
 import { createRoot } from 'react-dom/client';
 
-import { parseJSON } from '@/helpers/parseJSON.js';
+import { getProps } from '@/mask/custom-elements/props-pool.js';
 import { Widget } from '@/mask/custom-elements/Widget.js';
 
 export class WidgetWithProps<T> extends Widget {
-    get props() {
-        const raw = this.getAttribute('props');
-        if (!raw) return;
-
-        return parseJSON<T>(decodeURIComponent(raw));
-    }
-
     override connectedCallback() {
         this.root = createRoot(this);
-        this.root.render(<this.Component {...this.props} />);
+
+        const propsId = this.getAttribute('props-id');
+        const props = propsId ? (getProps(propsId) as T) : undefined;
+
+        this.root.render(<this.Component {...props} />);
     }
 }

--- a/src/mask/custom-elements/props-pool.ts
+++ b/src/mask/custom-elements/props-pool.ts
@@ -1,0 +1,12 @@
+const propsMap = new Map<string, unknown>();
+
+export function setProps(id: string, payloads: unknown) {
+    propsMap.set(id, payloads);
+    return () => {
+        propsMap.delete(id);
+    };
+}
+
+export function getProps(id: string) {
+    return propsMap.get(id);
+}


### PR DESCRIPTION
## Performance Improvement

- Reuse the payload object
- No `JSON.stringify` on big object or `JSON.parse` on large json
- No extra memory allocation for a copy of payload for Mask side.
- No large string in DOM or vDOM

