### PR TITLE
fix: fw-1896 avoid more action overflow in nft feed

### DIFF
--- a/src/components/NFTs/SingleNFTFeed.tsx
+++ b/src/components/NFTs/SingleNFTFeed.tsx
@@ -75,11 +75,11 @@ export const SingleNFTFeed = memo(function SingleNFTFeed({
             }}
         >
             <FeedFollowSource source={first(followingSources)} />
-            <div className="flex gap-3 overflow-auto">
+            <div className="flex gap-3">
                 <Link href={authorUrl} className="z-[1] flex-shrink-0" onClick={(event) => event.stopPropagation()}>
                     <Avatar className="h-10 w-10" src={displayInfo.avatarUrl} size={40} alt={ownerAddress} />
                 </Link>
-                <div className="flex-grow overflow-auto">
+                <div className="min-w-0 flex-grow">
                     <NFTFeedHeader
                         address={ownerAddress}
                         contractAddress={contractAddress}


### PR DESCRIPTION
https://mask.atlassian.net/browse/fw-1896

<img width="398" alt="image" src="https://github.com/user-attachments/assets/a8e38b2b-d64a-4e8b-a48b-d2ddb6b8d17e">

<img width="633" alt="image" src="https://github.com/user-attachments/assets/9fafbec9-ab6a-4ab5-ad5e-14f592879a2b">
