### PR TITLE
fix: improve handle tolerance for lens

### DIFF
--- a/src/providers/lens/SocialMedia.ts
+++ b/src/providers/lens/SocialMedia.ts
@@ -642,6 +642,10 @@ export class LensSocialMedia implements Provider {
     }
 
     async getProfileByHandle(handle: string): Promise<Profile> {
+        // Improve tolerance.
+        if (handle.endsWith('.lens')) {
+            handle = handle.slice(0, -5);
+        }
         const result = await lensSessionHolder.sdk.profile.fetch({
             forHandle: `lens/${handle}`,
         });


### PR DESCRIPTION
https://firefly.mask.social/profile/lens/binrui.lens/feed right now before this patch.

The Firefly API does already have such tolerance.

- https://api.firefly.land/v2/wallet/profile/?lensHandle=binrui
- https://api.firefly.land/v2/wallet/profile/?lensHandle=binrui.lens

<img width="1326" alt="image" src="https://github.com/user-attachments/assets/1006bc27-c71f-4295-ba44-8819a6ca8681">