### PR TITLE
fix: remove channel image alt

### DIFF
--- a/src/components/Posts/ChannelAnchor.tsx
+++ b/src/components/Posts/ChannelAnchor.tsx
@@ -49,12 +49,7 @@ export const ChannelAnchor = memo<ChannelAnchorProps>(function ChannelAnchor({
             <ChannelTippy channel={channel}>
                 <Link href={getChannelUrl(channel)} className="flex items-center gap-1">
                     {channel.imageUrl ? (
-                        <Avatar
-                            src={channel.imageUrl}
-                            alt={channel.id}
-                            size={15}
-                            className="h-[15px] w-[15px] rounded-full"
-                        />
+                        <Avatar src={channel.imageUrl} alt="" size={15} className="h-[15px] w-[15px] rounded-full" />
                     ) : (
                         <SocialSourceIcon className="rounded-full" source={channel.source} size={15} />
                     )}


### PR DESCRIPTION
The channel image is too small, cant display alt text

# Pull Request

## Description

<!-- Provide a brief description of the changes introduced by this pull request -->

## Related Issue

Closes FW-0000

<!-- Find your issue from: https://mask.atlassian.net/jira/software/c/projects/FW/boards/33/backlog -->

## Checklist

-   [ ] I have tested these changes locally.
-   [ ] I have reviewed the code changes.
-   [ ] I have added unit tests if applicable.